### PR TITLE
Update readme with license and new link to chrome web store

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 FreshEyes was created as a contest entry for [CarlHacks 2014](https://carlhacks.devpost.com/submissions), where it took first place. The idea was created by the team after one member voiced interest in attempting to develop something based on colorblindness. Two team members had deuteranomaly, a color deficiency resulting in difficulty discerning red and green colors.
 
-You can find the Chrome Extension on the [Web Store](https://chrome.google.com/webstore/detail/fresheyes/bgeggmjapkmjgniljnkgnbncpifgbnlk?hl=en).
+You can find the Chrome Extension on the [Web Store](https://chrome.google.com/webstore/detail/fresheyes/biaphhhbgcifjgpadjijmmbnoppfkenb).
 
 ## Creators of FreshEyes
 

--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@ You can find the Chrome Extension on the [Web Store](https://chrome.google.com/w
 [Márcio Porto](https://www.linkedin.com/in/marcioporto/)
 
 [Ana George](https://www.linkedin.com/in/ana-george/)
+
+## License
+
+The code of this extension is licensed under the GNU General Public License v3.0 (GPLv3).


### PR DESCRIPTION
This PR just updates the readme by mentioning the license and refreshing the link with the new one on the chrome web store (apparently they did not reassign the same extension id as before).